### PR TITLE
Problems with groovy-yaml dep from Devstack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.1.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
                     <groupId>com.eficode.shaded</groupId>
                     <artifactId>devstack</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- groovy-yaml is not available before v3 -->
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-yaml</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Excluding this dependency as it's not available in Groovy 2.5