### PR TITLE
0.2.1 Release

### DIFF
--- a/.github/workflows/publish-maven-package.yml
+++ b/.github/workflows/publish-maven-package.yml
@@ -41,14 +41,14 @@ jobs:
           
           mkdir -p repository/com/eficode/atlassian/bitbucketinstancemanager
           echo Compiling, Packaging and Installing Groovy 3.0 version of library to local m2 directory
-          mvn install -f pom.xml  -DcreateChecksum=true
+          mvn install -P groovy-3 -DcreateChecksum=true
 
 
       - name: Installing Groovy 2.5 Version
         run: |
           
           echo Compiling, Packaging and Installing Groovy 2.5 version of library to local m2 directory
-          mvn install -f pom.xml -DcreateChecksum=true -Dgroovy.major.version=2.5 -Dgroovy.version=2.5.18 -Dspock-core.version=2.2-groovy-2.5
+          mvn install -P groovy-2.5 -DcreateChecksum=true
       - name: Copying JAR files
         run: |
           echo Copying the new JAR files to repository which will be added to git branch "packages"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
 
     <dependencies>
 
-
         <dependency>
             <groupId>com.eficode</groupId>
             <artifactId>devstack</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
 
 
+
     <dependencies>
 
 
@@ -238,12 +239,33 @@
     </repositories>
 
 
+    <profiles>
+        <profile>
+            <id>groovy-3</id>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <groovy.major.version>3.0</groovy.major.version>
+                <groovy.version>3.0.13</groovy.version>
+                <spock-core.version>2.2-groovy-3.0</spock-core.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>groovy-2.5</id>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <groovy.major.version>2.5</groovy.major.version>
+                <groovy.version>2.5.18</groovy.version>
+                <spock-core.version>2.2-groovy-2.5</spock-core.version>
+            </properties>
+        </profile>
+    </profiles>
+
+
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <groovy.major.version>3.0</groovy.major.version>
-        <groovy.version>3.0.13</groovy.version>
-        <spock-core.version>2.3-groovy-3.0</spock-core.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eficode.atlassian</groupId>
     <artifactId>bitbucketinstancemanager</artifactId>
-    <version>0.2.0-SNAPSHOT-groovy-${groovy.major.version}</version>
+    <version>0.2.1-SNAPSHOT-groovy-${groovy.major.version}</version>
     <description>A groovy library for interacting with Bitbucket REST API</description>
     <packaging>jar</packaging>
 

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/BitbucketInstanceManagerRest.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/BitbucketInstanceManagerRest.groovy
@@ -42,7 +42,6 @@ class BitbucketInstanceManagerRest implements BitbucketEntity{
     String adminUsername
     String adminPassword
     String baseUrl
-    static ObjectMapper objectMapper = new ObjectMapper()
 
     BitbucketInstanceManagerRest(String username, String password, String baseUrl) {
         this.baseUrl = baseUrl

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketCommit.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketCommit.groovy
@@ -110,6 +110,11 @@ class BitbucketCommit implements BitbucketEntity {
 
         message.eachLine { mainOut += " * " + it + "\n" }
 
+        if (pr) {
+            mainOut += "\n\\\\\n ---- \n\\\\\n"
+            mainOut += pr.toAtlassianWikiMarkup()
+        }
+
         mainOut += "\n\\\\\n ---- \n\\\\\n"
 
 
@@ -131,7 +136,7 @@ class BitbucketCommit implements BitbucketEntity {
 
 
         String mainOut = "## Commit ID: " + displayId + (isAMerge() ? " " + mergerSymbol : "") + "\n" +
-                "**Author:** [${author.name}](${author.getProfileUrl(baseUrl)}) \n\n" +
+                "**Author:** ${author.toMarkdown()} \n\n" +
                 "**Timestamp:** " + dateFormat.format(new Date(timeStamp as long)) + "\n\n" +
                 "**Repository:** " + repository.toMarkdownUrl() + "\n\n" +
                 "**Branch:** " + branch.displayId + "\n\n" +
@@ -140,6 +145,13 @@ class BitbucketCommit implements BitbucketEntity {
 
 
         message.eachLine { mainOut += "\t" + it + "\n" }
+
+        BitbucketPullRequest pr = getPullRequest()
+        if (pr) {
+            mainOut += "\n\n"
+            mainOut += pr.toMarkdown()
+        }
+
 
         mainOut += "\n\n"
 

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketCommit.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketCommit.groovy
@@ -21,10 +21,10 @@ class BitbucketCommit implements BitbucketEntity {
     long committerTimestamp
     String message
     public BitbucketRepo repository
+    Map properties
     Logger log = LoggerFactory.getLogger(this.class)
 
     ArrayList<Map> parents = [["id": "", "displayId": ""]]
-    //ArrayList<Map<String,String>> parents = [["id": "", "displayId": ""]]
 
 
     static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketProject.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketProject.groovy
@@ -145,7 +145,7 @@ public class BitbucketProject implements BitbucketEntity {
         try {
             rawProject = getJsonPages(bbInstance.newUnirest, "/rest/api/1.0/projects/$projectKey" as String, 1, [:], false) as ArrayList<JsonNode>
         } catch (AssertionError ex) {
-            if (ex.message.containsIgnoreCase("Project $projectKey does not exist")) {
+            if (ex.message.toLowerCase().contains("Project $projectKey does not exist".toLowerCase())) {
                 return null
             } else {
                 throw ex

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketPullRequest.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketPullRequest.groovy
@@ -269,13 +269,13 @@ class BitbucketPullRequest implements BitbucketEntity {
 
     String toMarkdown() {
 
-        String mainOut = "##. Pull Request: $title (ID: $id)\n\n" +
+        String mainOut = "## Pull Request: $title (ID: $id)\n\n" +
                 "**Description:** \n\n${description.lines().collect {"\t" + it}.join("\n")}\n\n" +
-                "**State:** $state\n" +
-                "**Created:" + dateFormat.format(new Date(createdDate as long))  + "\n\n" +
-                "**Updated:**" + dateFormat.format(new Date(updatedDate as long)) + "\n\n" +
-                "**From Branch:**" + fromRef.displayId + "\t**To Branch:** " + toRef.displayId + "\n\n" +
-                "**Author:**" + author.toMarkdown() + "\n\n" +
+                "**State:** $state\n\n" +
+                "**Created:** " + dateFormat.format(new Date(createdDate as long))  + "\n\n" +
+                "**Updated:** " + dateFormat.format(new Date(updatedDate as long)) + "\n\n" +
+                "**From Branch:** " + fromRef.displayId + "\t**To Branch:** " + toRef.displayId + "\n\n" +
+                "**Author:** " + author.toMarkdown() + "\n\n" +
                 "**Reviewers:**\n" + reviewers.collect {"\t" + it.toMarkdown()}.join("\n") + "\n\n" +
                 "**Participants:**\n" + participants.collect {"\t" + it.toMarkdown()}.join("\n")
 

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketPullRequest.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketPullRequest.groovy
@@ -253,9 +253,9 @@ class BitbucketPullRequest implements BitbucketEntity {
         String mainOut = "h2. Pull Request: $title (ID: $id)\n\n" +
                 "*Description:* \n\n${description.lines().collect {"\t" + it}.join("\n")}\n\n" +
                 "*State:* $state\n" +
-                "*Created*:" + dateFormat.format(new Date(createdDate as long))  + "\n\n" +
-                "*Updated*:" + dateFormat.format(new Date(updatedDate as long)) + "\n\n" +
-                "*From Branch*:" + fromRef.displayId + "\t*To Branch:* " + toRef.displayId + "\n\n" +
+                "*Created:*" + dateFormat.format(new Date(createdDate as long))  + "\n\n" +
+                "*Updated:*" + dateFormat.format(new Date(updatedDate as long)) + "\n\n" +
+                "*From Branch:*" + fromRef.displayId + "\t*To Branch:* " + toRef.displayId + "\n\n" +
                 "*Author:* " + author.toAtlassianWikiMarkup() + "\n\n" +
                 "*Reviewers:*\n" + reviewers.collect {"\t" + it.toAtlassianWikiMarkup()}.join("\n") + "\n\n" +
                 "*Participants:*\n" + participants.collect {"\t" + it.toAtlassianWikiMarkup()}.join("\n")
@@ -264,6 +264,22 @@ class BitbucketPullRequest implements BitbucketEntity {
 
         return mainOut
 
+    }
+
+
+    String toMarkdown() {
+
+        String mainOut = "##. Pull Request: $title (ID: $id)\n\n" +
+                "**Description:** \n\n${description.lines().collect {"\t" + it}.join("\n")}\n\n" +
+                "**State:** $state\n" +
+                "**Created:" + dateFormat.format(new Date(createdDate as long))  + "\n\n" +
+                "**Updated:**" + dateFormat.format(new Date(updatedDate as long)) + "\n\n" +
+                "**From Branch:**" + fromRef.displayId + "\t**To Branch:** " + toRef.displayId + "\n\n" +
+                "**Author:**" + author.toMarkdown() + "\n\n" +
+                "**Reviewers:**\n" + reviewers.collect {"\t" + it.toMarkdown()}.join("\n") + "\n\n" +
+                "**Participants:**\n" + participants.collect {"\t" + it.toMarkdown()}.join("\n")
+
+        return mainOut
     }
 
 

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketPullRequestActivity.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketPullRequestActivity.groovy
@@ -13,6 +13,8 @@ class BitbucketPullRequestActivity implements BitbucketEntity{
     String action
     BitbucketCommit commit
     BitbucketPullRequest pullRequest
+    ArrayList<BitbucketUser>addedReviewers
+    ArrayList<BitbucketUser>removedReviewers
 
 
     @Override
@@ -20,6 +22,9 @@ class BitbucketPullRequestActivity implements BitbucketEntity{
         this.pullRequest = pullRequest as BitbucketPullRequest
 
         this.commit?.setParent(this.pullRequest.repo)
+
+        this.addedReviewers.each {it.setParent(instance)}
+        this.removedReviewers.each {it.setParent(instance)}
     }
 
     @Override

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketRepo.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketRepo.groovy
@@ -20,6 +20,7 @@ class BitbucketRepo implements BitbucketEntity {
     public String slug
     public String id
     public String name
+    public String description
     public String hierarchyId
     public String scmId
     public String state

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookBody.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookBody.groovy
@@ -25,7 +25,6 @@ class BitbucketWebhookBody implements BitbucketEntity {
     BitbucketRepo repository
     ArrayList<BitbucketWebhookChange> changes
 
-    static ObjectMapper objectMapper = new ObjectMapper()
 
     @Override
     void setParent(BitbucketEntity repo) {

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookBody.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookBody.groovy
@@ -63,7 +63,10 @@ class BitbucketWebhookBody {
 
         ArrayList<String> hrefs = bodyMap?.repository?.links?.self?.href
         String url = hrefs.size() ? hrefs.first() : null
-        url = url.contains("/projects") ? url.takeBefore("/projects") : null
+
+
+        url = url.contains("/projects") ? url.take(url.indexOf("/projects")) : null
+
         return url
     }
 

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookBody.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookBody.groovy
@@ -51,10 +51,17 @@ class BitbucketWebhookBody implements BitbucketEntity {
                 "Changes:\n"
 
         changes.each { change ->
+            BitbucketPullRequest pr = change?.toCommit?.pullRequest
+
             out += "\t\tCommit:\t" + change.toHash.take(11) + "\n"
             out += "\t\tBranch:\t" + change.branch.displayId + "\n"
             out += "\t\tType:\t" + change.type + "\n"
             out += "\t\tFrom commit:\t" + change.fromHash.take(11) + "\n"
+
+            if (pr) {
+                out += "\t\tPull Request:\t" + pr.toString() + "\n"
+                out += "\t\tPR Approved by:\t" + pr.approvers.collect {it.toString()}.join(",") + "\n"
+            }
 
         }
 

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookChange.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookChange.groovy
@@ -1,14 +1,47 @@
 package com.eficode.atlassian.bitbucketInstanceManager.impl
 
-class BitbucketWebhookChange {
+import com.eficode.atlassian.bitbucketInstanceManager.model.BitbucketEntity
+
+class BitbucketWebhookChange implements BitbucketEntity{
 
     BitbucketBranch ref
     String refId
     String fromHash
     String toHash
     String type
+    BitbucketRepo repository
+
+    boolean isValid() {
+        return isValidJsonEntity() && toHash && ref
+    }
+
+    @Override
+    void setParent(BitbucketEntity repo) {
+
+        this.repository = repo as BitbucketRepo
+
+
+    }
 
     BitbucketBranch getBranch() {
         return ref
     }
+
+    BitbucketCommit getToCommit() {
+        if (toHash) {
+            return repository.getCommit(toHash)
+        }else {
+            return null
+        }
+    }
+
+    BitbucketCommit getFromCommit() {
+        if (fromHash) {
+            return repository.getCommit(fromHash)
+        }else {
+            return null
+        }
+    }
+
+
 }

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookInvocation.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/impl/BitbucketWebhookInvocation.groovy
@@ -1,6 +1,7 @@
 package com.eficode.atlassian.bitbucketInstanceManager.impl
 
 import com.eficode.atlassian.bitbucketInstanceManager.model.WebhookEventType
+import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.databind.ObjectMapper
 
 import com.google.gson.reflect.TypeToken
@@ -36,6 +37,8 @@ class BitbucketWebhookInvocation {
         Integer statusCode
     }
 
+    @JsonAnySetter
+    Map<String, Object> dynamicValues = [:]
 
 
     static BitbucketWebhookInvocation fromJson(String jsonString) {

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketEntity.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketEntity.groovy
@@ -3,6 +3,8 @@ package com.eficode.atlassian.bitbucketInstanceManager.model
 import com.eficode.atlassian.bitbucketInstanceManager.BitbucketInstanceManagerRest
 import com.eficode.atlassian.bitbucketInstanceManager.impl.BitbucketPullRequest
 import com.eficode.atlassian.bitbucketInstanceManager.impl.BitbucketRepo
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 
@@ -33,6 +35,10 @@ trait BitbucketEntity {
 
 
     static ObjectMapper objectMapper = new ObjectMapper()
+
+
+    @JsonAnySetter
+    Map<String, Object> dynamicValues = [:]
 
     BitbucketInstanceManagerRest getInstance() {
         return this.localInstance

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketEntity.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketEntity.groovy
@@ -45,6 +45,15 @@ trait BitbucketEntity {
     }
 
 
+
+    static {
+        //Add Groovy 3 functionality, even if Groovy 2
+        String.metaClass.takeRight = {int num->
+            String src = delegate.toString()
+            return src.substring(src.length() - num, src.length())
+        }
+    }
+
     abstract void setParent(BitbucketEntity parent)
 
     /**

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketPrParticipant.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketPrParticipant.groovy
@@ -24,13 +24,16 @@ class BitbucketPrParticipant implements BitbucketEntity{
     }
 
     String toString() {
-        return user.toString() + " (${role})"
+        return user.toString() + " (Role: ${role.toLowerCase().capitalize()}, Status: ${status.toLowerCase().capitalize()})"
     }
 
     String toAtlassianWikiMarkup() {
         return user.toAtlassianWikiMarkup() + ", *Role:* " + role.toLowerCase().capitalize() + ", *Status:* " + status.toLowerCase().capitalize()
     }
 
+    String toMarkdown() {
+        return user.toMarkdown() + ", **Role:** " + role.toLowerCase().capitalize() + ", **Status:** " + status.toLowerCase().capitalize()
+    }
 
     @Override
     boolean isValid() {

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketUser.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketUser.groovy
@@ -39,8 +39,8 @@ class BitbucketUser implements BitbucketEntity{
     }
 
     @Override
-    void setParent(BitbucketEntity repo) {
-        this.instance = repo as BitbucketInstanceManagerRest
+    void setParent(BitbucketEntity instance) {
+        this.instance = instance as BitbucketInstanceManagerRest
     }
 
 

--- a/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketUser.groovy
+++ b/src/main/groovy/com/eficode/atlassian/bitbucketInstanceManager/model/BitbucketUser.groovy
@@ -53,6 +53,10 @@ class BitbucketUser implements BitbucketEntity{
         return "[~${name}] (Remote user: [${name}|${getProfileUrl(instance.baseUrl)}])"
     }
 
+    String toMarkdown() {
+        return "[${name}](${getProfileUrl(baseUrl)})"
+    }
+
 
     /**
      * Set the global permissions of one or several users

--- a/src/test/groovy/com/eficode/atlassian/bitbucketInstanceManger/BitbucketInstanceManagerRestSpec.groovy
+++ b/src/test/groovy/com/eficode/atlassian/bitbucketInstanceManger/BitbucketInstanceManagerRestSpec.groovy
@@ -76,8 +76,21 @@ class BitbucketInstanceManagerRestSpec extends Specification {
     File repoCacheDir = new File(mainTempDir, "main-repo-cache/").absoluteFile
 
 
+
+
     // run once before the first feature method
     def setupSpec() {
+
+        //Add the shuffle and takeRight methods, normally not available in groovy < 3
+        List.metaClass.shuffled = {  ->
+            Collections.shuffle(delegate as List<?>);
+            return delegate as List<?>
+        }
+        String.metaClass.takeRight = {int num->
+            String src = delegate.toString()
+            return src.substring(src.length() - num, src.length())
+        }
+
 
 
         if (dockerRemoteHost) {
@@ -619,6 +632,8 @@ class BitbucketInstanceManagerRestSpec extends Specification {
         foundHook.secret == secret
         foundHook.active
 
+
+
         expect:
 
         assert (unExpectedEvents ? bbRepo.getWebhooks(unExpectedEvents, 100).find { it.id == newHook.id } == null : true): "getWebhooks() returned webhook even though it should have been filtered out"
@@ -629,8 +644,8 @@ class BitbucketInstanceManagerRestSpec extends Specification {
         where:
         hookName        | events                                       | secret         | cleanProject
         "All events"    | WebhookEventType.values()                    | null           | true
-        "Random events" | WebhookEventType.values().shuffled().take(5) | null           | false
-        "With a secret" | WebhookEventType.values().shuffled().take(7) | "super secret" | false
+        "Random events" | WebhookEventType.values().toList().shuffled().take(5) | null           | false
+        "With a secret" | WebhookEventType.values().toList().shuffled().take(7) | "super secret" | false
 
 
     }


### PR DESCRIPTION
    Pom is now profile based, so if workflow to build
    Removed explicit ObjectMapper from classes that now inherit from trait
    Several improvements to support both Groovy 2 and 3
    BitbucketCommit
     * Improved toMarkdown & toAtlassianWikiMarkup, with PR
    BitbucketPullRequest.groovy
     * Improved toMarkdown & toAtlassianWikiMarkup
    BitbucketRepo.groovy
     * Added description
    BitbucketWebhookChange.groovy
     * Now implements BitbucketEntity
     * Added several helper methods
    BitbucketWebhookInvocation.groovy
     * Added dynamicValues as a catch-all for currently unknown json fields
    BitbucketEntity.groovy
     * Added dynamicValues as a catch-all for currently unknown json fields
     * Backported String.takeRight from Groovy 3
    BitbucketPrParticipant.groovy, BitbucketUser.groovy
     * Added toMarkdown